### PR TITLE
Added Feature: getFileCallback option for client widget working

### DIFF
--- a/js/elFinderInit.js
+++ b/js/elFinderInit.js
@@ -9,7 +9,7 @@ EzzeElFinder.init = function(selector, options) {
     }
 
     // Checking whether WYSIWYG editor is specified
-    if (typeof(options['wysiwyg']) === "string") {
+    if (typeof(options['wysiwyg']) === "string" && !options['getFileCallback']) {
 
         // Setting callback function according to used WYSIWYG editor
         if (options['wysiwyg'] === "ckeditor") {
@@ -24,6 +24,11 @@ EzzeElFinder.init = function(selector, options) {
         // TODO: implement your WYSIWYG editor's callback function here
 
         delete options['wysiwyg'];
+    }
+
+    if(typeof(options['getFileCallback']) === "string") {
+        var callback = new Function("file", options['getFileCallback']);
+        options['getFileCallback'] = callback;
     }
 
     EzzeElFinder.evaluateOptions(options);

--- a/php/elFinderVolumeDriver.class.php
+++ b/php/elFinderVolumeDriver.class.php
@@ -1371,7 +1371,7 @@ abstract class elFinderVolumeDriver {
 				} elseif ($file['mime'] == 'directory') {
 					return $this->setError(elFinder::ERROR_NOT_REPLACE, $name);
 				} 
-				$this->remove($file);
+				$this->remove($test);
 			} else {
 				$name = $this->uniqueName($dstpath, $name, '-', false);
 			}


### PR DESCRIPTION
I was trying to use the option getFileCallback documented here:

https://github.com/Studio-42/elFinder/wiki/Client-configuration-options#wiki-getFileCallback

I've changed your EzzeElfinder.init function to get the chance of embed code like this in the options array for your **ElFinderWidget**

``` PHP
$this->widget("application.common.extensions.ezzeelfinder.ElFinderWidget",
  array(
         'getFileCallback' => "console.log(file);",
  )
);
```

If **wysiwyg** option is defined too, getFileCallback takes preference.

My best regards.
